### PR TITLE
Fix ObjectNode serialization. The `required` attribute shouldn't be r…

### DIFF
--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -2,13 +2,13 @@
 mod extra_props;
 
 mod query_for_schema_node;
+mod schema_compiled;
 mod schema_node;
 mod schema_node_constructors;
 mod schema_node_for_literal;
 mod schema_node_from;
 mod schema_node_into;
 mod schema_node_into_compiled;
-mod schema_compiled;
 
 mod schema_description;
 
@@ -44,6 +44,8 @@ pub use string_node::StringNode;
 
 pub use schema_node_into_compiled::CompileError;
 
-
 #[cfg(test)]
 mod query_tests;
+
+#[cfg(test)]
+mod schema_node_test;

--- a/src/schema/object_node.rs
+++ b/src/schema/object_node.rs
@@ -9,7 +9,7 @@ use super::SchemaNode;
 pub struct ObjectNode {
     pub properties: HashMap<String, SchemaNode>,
 
-    #[serde(skip_serializing_if = "HashSet::is_empty")]
+    #[serde(default = "HashSet::new", skip_serializing_if = "HashSet::is_empty")]
     pub required: HashSet<String>,
 
     #[serde(skip_serializing_if = "HashMap::is_empty")]

--- a/src/schema/schema_node_test.rs
+++ b/src/schema/schema_node_test.rs
@@ -1,0 +1,49 @@
+use std::collections::HashSet;
+
+use super::*;
+
+#[test]
+fn test_serialize_schema_node_without_required() {
+    let schema_all_optional_str = r#"
+        {
+            "type": "object",
+            "properties": {
+                "opt_one": {
+                    "type": "integer"
+                },
+                "opt_two": {
+                    "type": "integer"
+                }
+            }
+        }
+    "#;
+
+    let schema_all_optional: SchemaNode = serde_json::from_str(schema_all_optional_str).unwrap();
+    assert!(
+        if let SchemaNode::ValidNode(ValidNode::ObjectNode(ref object_node)) = schema_all_optional {
+            assert_eq!(object_node.required, HashSet::new());
+            true
+        } else {
+            false
+        }
+    );
+}
+
+#[test]
+fn test_serialize_schema_node_into_invalid_node() {
+    let invalid_schema_str = r#"
+        {
+            "type": "object",
+            "required": []
+        }
+    "#;
+
+    let invalid_schema_str: SchemaNode = serde_json::from_str(invalid_schema_str).unwrap();
+    assert!(
+        if let SchemaNode::InvalidNode(ref _invalid_node) = invalid_schema_str {
+            true
+        } else {
+            false
+        }
+    );
+}


### PR DESCRIPTION
Currently, ObjectNode without explicit `required` attribute is serializing as InvalidNode.
PR provides the ability to serialize ObjectNode without the `required` attribute.